### PR TITLE
Allow translator to parse aliases in yaml files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,12 @@
 ## [0.1.0] - 2025-02-17
 
 - Initial release
+
+## [0.1.1] - 2025-04-23
+
+- Fix dependency for "fileutils"
+
+## [0.1.2] - 2025-05-08
+
+- Fix to allow parsing of YAML files with aliases
+- Fix CLI version command

--- a/Gemfile
+++ b/Gemfile
@@ -10,3 +10,5 @@ gem "rake", "~> 13.0"
 gem "minitest", "~> 5.16"
 
 gem "standard", "~> 1.3"
+
+gem "pry-nav"

--- a/lib/honyaku/cli.rb
+++ b/lib/honyaku/cli.rb
@@ -118,6 +118,11 @@ module Honyaku
       puts "✅ Fixes complete!"
     end
 
+    desc "version", "Show Honyaku version"
+    def version
+      puts "Honyaku v#{Honyaku::VERSION}"
+    end
+
     private
 
     def find_translation_rules(start_path, target_locale = nil)
@@ -310,11 +315,6 @@ module Honyaku
     def status
       puts "📊 Translation Status:"
       # Status reporting logic will go here
-    end
-
-    desc "version", "Show Honyaku version"
-    def version
-      puts "Honyaku v#{Honyaku::VERSION}"
     end
 
     def self.exit_on_failure?

--- a/lib/honyaku/translator.rb
+++ b/lib/honyaku/translator.rb
@@ -47,7 +47,7 @@ module Honyaku
       
       loop do
         begin
-          YAML.load(content)
+          YAML.load(content, aliases: true)
           puts "✅ No more YAML errors found"
           return content
         rescue Psych::SyntaxError => e

--- a/lib/honyaku/translator.rb
+++ b/lib/honyaku/translator.rb
@@ -47,7 +47,7 @@ module Honyaku
       
       loop do
         begin
-          YAML.load(content, aliases: true)
+          YAML.safe_load(content, aliases: true)
           puts "✅ No more YAML errors found"
           return content
         rescue Psych::SyntaxError => e

--- a/lib/honyaku/version.rb
+++ b/lib/honyaku/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Honyaku
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end

--- a/test/test_honyaku_aliases.rb
+++ b/test/test_honyaku_aliases.rb
@@ -1,0 +1,40 @@
+require 'minitest/autorun'
+require 'honyaku'
+require 'tempfile'
+require 'yaml'
+require 'json'
+require 'pry'
+require 'pry-nav'
+
+class HonyakuAliasTest < Minitest::Test
+
+  # Verifies YAML file containing aliases does not throw an error
+  def test_translates_yaml_with_aliases
+    yaml_content = <<~YAML
+      common: &common
+        greeting: Hello
+        farewell: Goodbye
+      
+      english:
+        <<: *common
+        extra: Additional text
+      
+      spanish:
+        <<: *common
+        extra: Texto adicional
+    YAML
+
+    temp_file = Tempfile.new(['test', '.yml'])
+    temp_file.write(yaml_content)
+    temp_file.close
+
+    translator = Honyaku::Translator.new(
+      api_key: 'fake_key',
+      model: 'gpt-4o-mini'
+    )
+
+    translator.fix_yaml(temp_file.path)
+  ensure
+    temp_file.unlink
+  end
+end


### PR DESCRIPTION
Fixes the error when running the translator against a YAML file that contains `aliases` ([example](https://www.educative.io/blog/advanced-yaml-syntax-cheatsheet#YAML-Anchors-and-Alias))

To run test:
```
bundle exec ruby test/test_honyaku_aliases.rb
```

**Before**
<img width="1139" alt="Screenshot 2025-05-06 at 1 59 09 PM" src="https://github.com/user-attachments/assets/52842b18-aede-438c-bfb7-4de5435ac8ce" />

**After**
<img width="449" alt="Screenshot 2025-05-06 at 3 16 56 PM" src="https://github.com/user-attachments/assets/a4bcd365-cdb7-4fdf-a773-93db745d43e3" />

---

**Before**
<img width="260" alt="Screenshot 2025-05-06 at 3 17 12 PM" src="https://github.com/user-attachments/assets/6504d165-dcdc-4ba1-9c91-720d01b37de0" />

**After**
<img width="136" alt="Screenshot 2025-05-06 at 3 17 19 PM" src="https://github.com/user-attachments/assets/1d22d34a-9dad-4f43-9152-2d28df6fda9d" />

