### PR TITLE
[WIP] Feature: allow keeping files when the result produces errors in yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,7 @@
 
 - Fix to allow parsing of YAML files with aliases
 - Fix CLI version command
+
+## [0.1.3] - 2025-05-30
+
+- Allow option to keep files with errors in the YAML formatting

--- a/lib/honyaku/version.rb
+++ b/lib/honyaku/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Honyaku
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
+require "minitest/autorun"
 require "honyaku"
 
-require "minitest/autorun"
+# Add the lib directory to the load path
+$LOAD_PATH.unshift File.expand_path("../lib", __dir__)

--- a/test/test_honyaku.rb
+++ b/test/test_honyaku.rb
@@ -1,13 +1,40 @@
 # frozen_string_literal: true
 
-require "test_helper"
+require_relative "test_helper"
 
 class TestHonyaku < Minitest::Test
   def test_that_it_has_a_version_number
     refute_nil ::Honyaku::VERSION
   end
 
-  def test_it_does_something_useful
-    assert false
+  def test_keep_invalid_flag_preserves_file
+    # Create a temporary directory for our test files
+    Dir.mktmpdir do |dir|
+      # Create a source file with valid YAML
+      source_file = File.join(dir, "en.yml")
+      File.write(source_file, "en:\n  hello: Hello")
+
+      # Create a target file with invalid YAML
+      target_file = File.join(dir, "ja.yml")
+      File.write(target_file, "ja:\n  hello: こんにちは\n  invalid: [unclosed array")
+
+      # Mock the translator to simulate YAML validation failure
+      translator = Minitest::Mock.new
+      translator.expect :translate_hash, "ja:\n  hello: こんにちは\n  invalid: [unclosed array", [String, String, String]
+      translator.expect :fix_yaml, nil do |file|
+        raise "needs retranslation" # Simulate YAML validation failure
+      end
+
+      # Create CLI instance with keep_invalid flag
+      cli = Honyaku::CLI.new
+      cli.options = { keep_invalid: true }
+
+      # Run the translation
+      cli.send(:process_file, source_file, translator, "en", "ja")
+
+      # Verify the file still exists despite the error
+      assert File.exist?(target_file), "File should be preserved when keep_invalid is true"
+      assert_equal "ja:\n  hello: こんにちは\n  invalid: [unclosed array", File.read(target_file)
+    end
   end
 end


### PR DESCRIPTION
Example:
```
honyaku translate ja --keep-invalid
```