### PR TITLE
[WIP] Feat: Support retranslating files XP to retranslate files with newly added keys but doesn't retranslate every key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [0.1.3] - 2025-07-10
+
+- Add support for retranslating files with previous translations, adding only newly added keys
+
 ## [0.1.0] - 2025-02-17
 
 - Initial release

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Honyaku was built using [Cursor Composer](https://docs.cursor.com/composer) with
 - Handles large files through automatic chunking
 - Automatically fixes YAML formatting issues caused by the GPT
 - Smart file skipping to avoid unnecessary retranslation
+- Supports retranslating files with previous translations, adding only newly added keys
 
 # Example Output
 

--- a/lib/honyaku/cli.rb
+++ b/lib/honyaku/cli.rb
@@ -192,8 +192,13 @@ module Honyaku
         target_time = get_last_modified_time(target_file)
 
         if target_time && source_time && target_time > source_time
-          puts "⏭️  Skipping #{file_path} - translation is up to date"
-          return
+          # Check if source has new keys that aren't in target
+          if has_new_keys?(file_path, target_file)
+            puts "🔄 Found new keys in #{file_path}, updating translation..."
+          else
+            puts "⏭️  Skipping #{file_path} - translation is up to date"
+            return
+          end
         end
       end
 
@@ -309,6 +314,55 @@ module Honyaku
       Time.parse(time_str)
     rescue
       nil
+    end
+
+    def has_new_keys?(source_file, target_file)
+      begin
+        source_data = YAML.safe_load(File.read(source_file), aliases: true)
+        target_data = YAML.safe_load(File.read(target_file), aliases: true)
+        
+        # Extract keys from the nested locale content (skip top-level locale keys)
+        source_keys = []
+        target_keys = []
+        
+        # For each top-level locale, extract its nested keys
+        source_data.each do |locale, content|
+          source_keys.concat(extract_all_keys(content)) if content.is_a?(Hash)
+        end
+        
+        target_data.each do |locale, content|
+          target_keys.concat(extract_all_keys(content)) if content.is_a?(Hash)
+        end
+        
+        # Check if source has keys that target doesn't have
+        new_keys = source_keys - target_keys
+        new_keys.any?
+      rescue => e
+        # If we can't parse either file, err on the side of caution and retranslate
+        puts "⚠️  Unable to compare keys (#{e.message}), will retranslate"
+        true
+      end
+    end
+
+    def extract_all_keys(data, prefix = "")
+      keys = []
+      
+      case data
+      when Hash
+        data.each do |key, value|
+          current_key = prefix.empty? ? key.to_s : "#{prefix}.#{key}"
+          keys << current_key
+          keys.concat(extract_all_keys(value, current_key))
+        end
+      when Array
+        data.each_with_index do |value, index|
+          current_key = "#{prefix}[#{index}]"
+          keys << current_key
+          keys.concat(extract_all_keys(value, current_key))
+        end
+      end
+      
+      keys
     end
 
     desc "status", "Show translation status for all locales"

--- a/lib/honyaku/version.rb
+++ b/lib/honyaku/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Honyaku
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end


### PR DESCRIPTION
**Summary**
  Adds support for retranslating files that contain new keys, even when the target translation file is newer than the source.

 **Changes**
  - Enhanced file comparison logic: The CLI now checks if source files have new keys that aren't present in the target translation files, not just modification timestamps
  - Added has_new_keys? method: Compares YAML structures between source and target files to identify newly added translation keys
  - Added extract_all_keys method: Recursively extracts all keys from nested YAML structures (including arrays and nested hashes)
  - Improved user feedback: Shows "🔄 Found new keys in [file], updating translation..." when new keys are detected

 **Behavior**
  Previously, the CLI would skip translation if the target file was newer than the source. Now it will:
  1. First check if the target is newer than the source
  2. If so, compare the actual keys in both files
  3. If new keys are found in the source, proceed with translation
  4. If no new keys are found, skip as before